### PR TITLE
Handle already existing TZ from string

### DIFF
--- a/src/Date/DateUtils.php
+++ b/src/Date/DateUtils.php
@@ -57,11 +57,12 @@ class DateUtils
      */
     public static function fromString(string $str, ?string $format = null): \DateTimeImmutable
     {
-        return self::fromStringTz(
-            $str,
-            new \DateTimeZone(date_default_timezone_get()),
-            $format
-        );
+        $naiveDate = date_create($str);
+        $timeZone = false !== $naiveDate
+            ? $naiveDate->getTimezone()
+            : new \DateTimeZone(date_default_timezone_get());
+
+        return self::fromStringTz($str, $timeZone, $format);
     }
 
     /**

--- a/tests/Date/DateUtilsTest.php
+++ b/tests/Date/DateUtilsTest.php
@@ -31,6 +31,10 @@ class DateUtilsTest extends TestCase
         self::assertEquals('86400', $day5->getTimestamp());
         self::assertEquals('Europe/Paris', $day5->getTimezone()->getName());
         self::assertEquals('1970-01-02 00:00:00', $day6->format('Y-m-d H:i:s'));
+
+        $day7 = DateUtils::fromString('04-01-1970 00:00:00+12:00');
+        self::assertEquals('1970-01-04', $day7->format('Y-m-d'));
+        self::assertEquals('+12:00', $day7->getTimezone()->getName());
     }
 
     public function testFromStringMutable(): void


### PR DESCRIPTION
When TimeZone was already included in given string, it was ignored.

Here we try first to instantiate a dummy date in order to get a potential TimeZone and then we apply it to the newly created date.