### PR TITLE
Implement hrtime methods in Clock

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,7 +7,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__.'/tests')
     ->name('*.php')
     ->append([__FILE__])
-    ;
+;
 
 return (new PhpCsFixer\Config())
     ->setRules([

--- a/src/Clock/Clock.php
+++ b/src/Clock/Clock.php
@@ -2,6 +2,8 @@
 
 namespace Mention\Kebab\Clock;
 
+use Mention\Kebab\Clock\Exception\IncompatibleSystemException;
+
 /**
  * Clock is a collection of mockable time-related functions.
  *
@@ -14,12 +16,18 @@ namespace Mention\Kebab\Clock;
  */
 class Clock
 {
-    /** @var ?float */
-    private static $now;
+    /**
+     * @var ?float number of seconds since the Unix Epoch (January 1
+     *             1970 00:00:00 GMT) or null if not mocked
+     */
+    private static ?float $now;
 
+    /**
+     * @param null|float $time number of seconds
+     */
     public static function enableMocking(?float $time = null): void
     {
-        self::$now = $time ?? microtime(true);
+        self::travelTo($time ?? microtime(true));
     }
 
     public static function disableMocking(): void
@@ -27,6 +35,11 @@ class Clock
         self::$now = null;
     }
 
+    /**
+     * @see https://www.php.net/manual/en/function.microtime.php
+     *
+     * @return float number of seconds
+     */
     public static function microtimeFloat(): float
     {
         if (null === self::$now) {
@@ -36,6 +49,11 @@ class Clock
         return self::$now;
     }
 
+    /**
+     * @see https://www.php.net/manual/en/function.microtime.php
+     *
+     * @return string of the form "0.32107100 1668868618"
+     */
     public static function microtimeString(): string
     {
         if (null === self::$now) {
@@ -45,6 +63,11 @@ class Clock
         return sprintf('%0.6f %d', self::$now - (int) self::$now, (int) self::$now);
     }
 
+    /**
+     * @see https://www.php.net/manual/en/function.time.php
+     *
+     * @return int number of seconds
+     */
     public static function time(): int
     {
         if (null === self::$now) {
@@ -55,19 +78,36 @@ class Clock
     }
 
     /**
-     * @return int|false
+     * @see https://www.php.net/manual/en/function.sleep.php
+     *
+     * @param positive-int|0 $s number of seconds
+     *
+     * @return int an error code or a number of remaining seconds
      */
-    public static function sleep(int $s)
+    public static function sleep(int $s): int
     {
         if (null === self::$now) {
-            return sleep($s);
+            $i = sleep($s);
+
+            if (false === $i) {
+                // Since PHP 8.0 sleep does not return false anymore and throws instead.
+                // Emulating behavior here for consistency.
+                throw new \ValueError();
+            }
+
+            return $i;
         }
 
-        self::$now += $s;
+        self::travelTo(self::$now + $s);
 
         return 0;
     }
 
+    /**
+     * @see https://www.php.net/manual/en/function.usleep.php
+     *
+     * @param positive-int|0 $us number of microseconds (seconds/1e+6)
+     */
     public static function usleep(int $us): void
     {
         if (null === self::$now) {
@@ -76,6 +116,83 @@ class Clock
             return;
         }
 
-        self::$now += (float) $us / 1000000;
+        self::travelTo(self::$now + (float) $us / 1000000);
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/function.hrtime.php
+     *
+     * @return array{0: int, 1: int}
+     */
+    public static function hrtimeArray(): array
+    {
+        if (null === self::$now) {
+            return hrtime(false);
+        }
+
+        $seconds = (int) self::$now;
+
+        return [
+            // Whole seconds
+            $seconds,
+            // Remaining nanoseconds
+            (int) round((self::$now - $seconds) * 1e+9),
+        ];
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/function.hrtime.php
+     *
+     * Must be used under php 64bit version.
+     *
+     * @throws IncompatibleSystemException if used with php 32bit version
+     *
+     * @return int number of nanoseconds (seconds/1e+9)
+     */
+    public static function hrtimeInt(): int
+    {
+        if (is_float(hrtime(true))) {
+            // Can't cast float to int safely
+            throw IncompatibleSystemException::expected64();
+        }
+
+        if (null === self::$now) {
+            return hrtime(true);
+        }
+
+        // On php 64bit version it will be ok to cast until year 2262
+        return (int) (self::$now * 1e+9);
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/function.hrtime.php
+     *
+     * Can be safely used under php 32bit and 64 bit versions.
+     *
+     * @return float number of nanoseconds (seconds/1e+9)
+     */
+    public static function hrtimeFloat(): float
+    {
+        if (null === self::$now) {
+            return (float) hrtime(true);
+        }
+
+        return self::$now * 1e+9;
+    }
+
+    /**
+     * Since we need to be able to cast $now from float to int we
+     * are forbidding to set a date too far in the future.
+     */
+    private static function travelTo(float $now): void
+    {
+        if ($now > PHP_INT_MAX) {
+            throw new \LogicException(sprintf(
+                'Trying to travel in the future after year %d is not supported',
+                PHP_INT_MAX / 60 / 60 / 24 / 7 / 365,
+            ));
+        }
+
+        self::$now = $now;
     }
 }

--- a/src/Clock/Exception/IncompatibleSystemException.php
+++ b/src/Clock/Exception/IncompatibleSystemException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Mention\Kebab\Clock\Exception;
+
+class IncompatibleSystemException extends \Exception
+{
+    private function __construct(int $system)
+    {
+        parent::__construct(sprintf(
+            'Method can only be used with php %dbit versions',
+            $system,
+        ));
+    }
+
+    public static function expected64(): self
+    {
+        return new self(64);
+    }
+}

--- a/src/Pcre/PcreUtils.php
+++ b/src/Pcre/PcreUtils.php
@@ -14,7 +14,8 @@ class PcreUtils
      *
      * @see https://www.php.net/manual/en/function.preg-match.php
      *
-     * @param array<string> $matches
+     * @param array<string>                                           $matches
+     * @param int-mask-of<PREG_OFFSET_CAPTURE|PREG_UNMATCHED_AS_NULL> $flags
      */
     public static function match(
         string $pattern,
@@ -308,8 +309,6 @@ class PcreUtils
             throw PcreException::fromLastError();
         }
 
-        assert(is_string($matched));
-
         return $matched;
     }
 
@@ -342,8 +341,6 @@ class PcreUtils
             throw PcreException::fromLastError();
         }
 
-        assert(is_string($matched));
-
         return $matched;
     }
 
@@ -366,15 +363,7 @@ class PcreUtils
         int $limit = -1,
         ?int &$count = null
     ): array {
-        $matched = preg_filter($pattern, $replacement, $subjects, $limit, $count);
-
-        if (null === $matched) {
-            throw PcreException::fromLastError();
-        }
-
-        assert(is_array($matched));
-
-        return $matched;
+        return preg_filter($pattern, $replacement, $subjects, $limit, $count);
     }
 
     /**
@@ -396,21 +385,13 @@ class PcreUtils
         int $limit = -1,
         ?int &$count = null
     ): array {
-        $matched = preg_filter(
+        return preg_filter(
             array_keys($patternsAndReplacements),
             array_values($patternsAndReplacements),
             $subjects,
             $limit,
             $count
         );
-
-        if (null === $matched) {
-            throw PcreException::fromLastError();
-        }
-
-        assert(is_array($matched));
-
-        return $matched;
     }
 
     /**

--- a/tests/Clock/ClockTest.php
+++ b/tests/Clock/ClockTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Mention\Kebab\Tests\Clock;
+
+use Mention\Kebab\Clock\Clock;
+use Mention\Kebab\Clock\Exception\IncompatibleSystemException;
+use PHPUnit\Framework\TestCase;
+
+class ClockTest extends TestCase
+{
+    public function testHrtimeArray(): void
+    {
+        Clock::enableMocking(0.0); // Let's travel through time!
+        $start = Clock::hrtimeArray();
+        $new = Clock::hrtimeArray();
+        self::assertEquals($start[0], $new[0]);
+        self::assertEquals($start[1], $new[1]);
+
+        // 1 second and 5 milliseconds to the future
+        Clock::usleep(1005000);
+        $new = Clock::hrtimeArray();
+        self::assertEquals(1, $new[0] - $start[0]);
+        // 5 milliseconds is 5M nanoseconds
+        self::assertEquals(5 * 1e+6, $new[1] - $start[1]);
+    }
+
+    public function testHrtimeInt(): void
+    {
+        // Different tests depending on the php version executed
+        switch (PHP_INT_SIZE) {
+            case 8:
+                Clock::enableMocking(0.0); // Let's travel through time!
+                $start = Clock::hrtimeInt();
+                $new = Clock::hrtimeInt();
+                self::assertEquals($start, $new);
+                self::assertEquals($start, $new);
+
+                // 25 microseconds to the future
+                Clock::usleep(25);
+                $new = Clock::hrtimeInt();
+                // 25 microseconds is 25k nanoseconds
+                self::assertEquals(25 * 1e+3, $new - $start);
+
+                break;
+            case 4:
+                $e = null;
+
+                try {
+                    Clock::hrtimeInt();
+                } catch (IncompatibleSystemException $e) {
+                }
+
+                self::assertNotNull($e);
+
+                break;
+            default:
+                throw new \Exception(sprintf(
+                    'A specific test for php version using PHP_INT_SIZE of %d should be added',
+                    PHP_INT_SIZE,
+                ));
+        }
+    }
+
+    public function testHrtimeFloat(): void
+    {
+        Clock::enableMocking(0.0); // Let's travel through time!
+        $start = Clock::hrtimeFloat();
+        $new = Clock::hrtimeFloat();
+        self::assertEquals($start, $new);
+        self::assertEquals($start, $new);
+
+        // 25 microseconds to the future
+        Clock::usleep(25);
+        $new = Clock::hrtimeFloat();
+        // 25 microseconds is 25k nanoseconds
+        self::assertEquals(25 * 1e+3, $new - $start);
+    }
+}


### PR DESCRIPTION
I need to use `hrtime` to measure execution time and adding it to Clock allow us to enjoy good typing and mocked time.
I also add a bit of documentation, units disambiguation and fixed some other files for phpstan.