### PR TITLE
:kebab-parrot: Hard-typed property must be explicitely initialized to null

### DIFF
--- a/src/Clock/Clock.php
+++ b/src/Clock/Clock.php
@@ -20,7 +20,7 @@ class Clock
      * @var ?float number of seconds since the Unix Epoch (January 1
      *             1970 00:00:00 GMT) or null if not mocked
      */
-    private static ?float $now;
+    private static ?float $now = null; // Not mocked by default
 
     /**
      * @param null|float $time number of seconds


### PR DESCRIPTION
Since we hard-type `$now` to be a `null|float`, the default type `undefined` (before initialization) became invalid.
Clock being a static class we can't use constructor to initialize the value therefore we are doing it at prop declaration directely.